### PR TITLE
Verify OIDC id_token audience claim

### DIFF
--- a/datacatalog/authentication/pyoidc_authentication.py
+++ b/datacatalog/authentication/pyoidc_authentication.py
@@ -231,7 +231,13 @@ class PyOIDCAuthentication(RemoteAuthentication):
             return TokenErrorResponse(**response)
         else:
             token = AccessTokenResponse(**response)
-            token.verify(keyjar=self.oidc_client.keyjar, skew=SKEW)
+            # pass client_id so the id_token "aud" (and "azp") claim is verified;
+            # without it pyoidc silently skips the audience check
+            token.verify(
+                keyjar=self.oidc_client.keyjar,
+                skew=SKEW,
+                client_id=self.oidc_client.client_id,
+            )
             # check nonce in id_token
             id_token = token["id_token"]
             if id_token["nonce"] != session.get("nonce", "undefined"):


### PR DESCRIPTION
pyoidc only checks the id_token `aud`/`azp` claim when `client_id` is passed to `verify()`. The login and refresh paths omitted it, so the audience check was silently skipped.

- Pass `client_id` in `get_token` and `check_and_refresh`.
- Handle a refresh verification failure by logging the user out.