### PR TITLE
Fix my-applications page issues and add log rotation

### DIFF
--- a/datacatalog/controllers/web_controllers.py
+++ b/datacatalog/controllers/web_controllers.py
@@ -711,6 +711,7 @@ def my_applications(entity_name):
         applications = [
             a for a in applications if a.state is not ApplicationState.approved
         ]
+    applications = [a for a in applications if a.state is not ApplicationState.closed]
     if any([a.state is None for a in applications]):
         logger.error(
             "An error occurred while loading some applications: Unknown state retrieved"

--- a/datacatalog/settings.py.template
+++ b/datacatalog/settings.py.template
@@ -227,8 +227,10 @@ class Config(object):
             "file": {
                 "level": "DEBUG",
                 "formatter": "standard",
-                "class": "logging.FileHandler",
+                "class": "logging.handlers.RotatingFileHandler",
                 "filename": "datacatalog.log",
+                "maxBytes": 50_000_000,
+                "backupCount": 4,
             },
         },
         "loggers": {

--- a/datacatalog/templates/my_applications.html
+++ b/datacatalog/templates/my_applications.html
@@ -39,7 +39,7 @@
         {% for entity in entities_with_access %}
           <li>
             <a href="{{ url_for('entity_details', entity_name=entity_name, entity_id=entity.id) }}"
-               class="group flex items-center justify-between gap-4 py-3 hover:bg-gray-50">
+               class="group flex items-center gap-2 py-3 hover:bg-gray-50">
               <span class="text-base font-semibold leading-snug text-blue-900 group-hover:text-blue-800 group-hover:underline group-hover:underline-offset-2 lg:text-lg">{{ entity.title }}</span>
               <i data-lucide="circle-check" class="h-5 w-5 shrink-0 text-blue-900"></i>
             </a>


### PR DESCRIPTION
- Hide closed (user-cancelled) applications from the data access requests table
- Align the access icon next to the dataset name on the accessible datasets list
- Rotate `datacatalog.log` via `RotatingFileHandler` (50 MB, 4 backups)