### PR TITLE
Require login for access requests by default

### DIFF
--- a/datacatalog/acces_handler/email_handler.py
+++ b/datacatalog/acces_handler/email_handler.py
@@ -90,4 +90,7 @@ class EmailAccessHandler(AccessHandler):
             self.name = self.user.id
             del form.email
             del form.name
+            # the captcha guards against anonymous bot submissions, login
+            # already establishes the identity
+            del form.recaptcha
         return form

--- a/datacatalog/acces_handler/email_handler.py
+++ b/datacatalog/acces_handler/email_handler.py
@@ -84,7 +84,9 @@ class EmailAccessHandler(AccessHandler):
 
     def create_form(self, dataset, form_data):
         logger.debug("Creating form for email request")
-        form = RequestAccess(form_data)
+        # passing formdata=None explicitly stops FlaskForm from picking up
+        # request.form, so leave it out entirely when there is no data
+        form = RequestAccess() if form_data is None else RequestAccess(form_data)
         if self.user.is_authenticated:
             self.email = self.user.email or self.user.id
             self.name = self.user.id

--- a/datacatalog/controllers/web_controllers.py
+++ b/datacatalog/controllers/web_controllers.py
@@ -649,7 +649,9 @@ def request_access(entity_name: str, entity_id: str) -> Response:
         url_submit += f"?type={specified_type}"
     if request.method == "POST":
         if not form.validate():
-            if hasattr(form, "recaptcha") and form.recaptcha.errors:
+            # the field is absent on the rems forms and set to None once
+            # deleted for a logged in user, so hasattr is not enough
+            if getattr(form, "recaptcha", None) and form.recaptcha.errors:
                 flash("The Captcha response parameter is missing.", category="error")
             logger.info("invalid form")
             return render_template(template, form=form, **kwargs)

--- a/datacatalog/controllers/web_controllers.py
+++ b/datacatalog/controllers/web_controllers.py
@@ -621,7 +621,10 @@ def request_access(entity_name: str, entity_id: str) -> Response:
     logger.info(
         "Using handler %s with template %s", handler.__class__.__name__, template
     )
-    if handler.requires_logged_in_user(entity) and not current_user.is_authenticated:
+    require_login = app.config.get(
+        "REQUIRE_LOGIN_ACCESS_REQUEST", True
+    ) or handler.requires_logged_in_user(entity)
+    if require_login and not current_user.is_authenticated:
         logger.info("Redirecting user to login")
         here = request.full_path
         redirect_url = url_for("login") + f"?next={here}"

--- a/datacatalog/settings.py.template
+++ b/datacatalog/settings.py.template
@@ -180,6 +180,9 @@ class Config(object):
     PYOIDC_IDP_URL = os.environ.get("PYOIDC_IDP_URL", "")
     # DISPLAY THE 'LOGIN' LINK IN NAVBAR
     SHOW_LOGIN = False
+    # IF TRUE, USERS MUST BE LOGGED IN TO SUBMIT AN ACCESS REQUEST, WHATEVER THE ACCESS HANDLER
+    # SET TO FALSE TO LET THE HANDLER DECIDE (E.G. ANONYMOUS EMAIL REQUESTS)
+    REQUIRE_LOGIN_ACCESS_REQUEST = True
     # ACCESS HANDLER (used for access requests)
     # Rems, RemsOidc or Email
     # RemsOidc handler will use rems to create access requests and pull requests statuses but actual accesses will be

--- a/tests/controllers/test_access_request.py
+++ b/tests/controllers/test_access_request.py
@@ -18,12 +18,16 @@
 
 
 import unittest
+from unittest.mock import patch
 
 from flask import url_for
+from flask_login import AnonymousUserMixin
 
 from tests.base_test import BaseTest
 from datacatalog import app, mail
+from datacatalog.acces_handler.email_handler import EmailAccessHandler
 from datacatalog.models.dataset import Dataset
+from datacatalog.models.user import User
 
 app.testing = True
 
@@ -66,6 +70,33 @@ class TestAccessRequest(BaseTest):
             )
             self.assertEqual(rv.status_code, 302)
             self.assertIn(url_for("login"), rv.location)
+
+    def test_email_form_drops_recaptcha_for_logged_in_user(self):
+        dataset = Dataset.query.get(self.dataset_id)
+        with app.test_request_context():
+            handler = EmailAccessHandler(User("test", "test@example.org", "Test User"))
+            form = handler.create_form(dataset, None)
+            # wtforms sets deleted fields to None instead of dropping the
+            # attribute, _fields is what drives validation and rendering
+            self.assertNotIn("recaptcha", form._fields)
+
+    def test_email_form_keeps_recaptcha_for_anonymous_user(self):
+        dataset = Dataset.query.get(self.dataset_id)
+        with app.test_request_context():
+            handler = EmailAccessHandler(AnonymousUserMixin())
+            form = handler.create_form(dataset, None)
+            self.assertIn("recaptcha", form._fields)
+
+    @patch("flask_login.utils._get_user")
+    def test_email_invalid_form_logged_in_user(self, current_user):
+        """An empty submission must re-render the form, not fail on the
+        recaptcha field the handler just deleted."""
+        app.config["ACCESS_HANDLERS"] = {"dataset": "Email"}
+        current_user.return_value = User("test", "test@example.org", "Test User")
+        rv = app.test_client().post(
+            url_for("request_access", entity_name="dataset", entity_id=self.dataset_id)
+        )
+        self.assertEqual(rv.status_code, 200)
 
     @unittest.skip("Not included in the test")
     def test_mail(self):

--- a/tests/controllers/test_access_request.py
+++ b/tests/controllers/test_access_request.py
@@ -46,12 +46,26 @@ class TestAccessRequest(BaseTest):
     def test_email_request_access(self):
         with app.test_client() as client:
             app.config["ACCESS_HANDLERS"] = {"dataset": "Email"}
+            # the email handler only accepts anonymous requests once the
+            # catalogue-wide login requirement is lifted
+            app.config["REQUIRE_LOGIN_ACCESS_REQUEST"] = False
             rv = client.post(
                 url_for(
                     "request_access", entity_name="dataset", entity_id=self.dataset_id
                 )
             )
             self.assertEqual(rv.status_code, 200)
+
+    def test_email_request_access_requires_login_by_default(self):
+        with app.test_client() as client:
+            app.config["ACCESS_HANDLERS"] = {"dataset": "Email"}
+            rv = client.get(
+                url_for(
+                    "request_access", entity_name="dataset", entity_id=self.dataset_id
+                )
+            )
+            self.assertEqual(rv.status_code, 302)
+            self.assertIn(url_for("login"), rv.location)
 
     @unittest.skip("Not included in the test")
     def test_mail(self):
@@ -63,5 +77,6 @@ class TestAccessRequest(BaseTest):
             assert outbox[0].subject == "testing"
 
     def tearDown(self):
+        app.config["REQUIRE_LOGIN_ACCESS_REQUEST"] = True
         app.config["_solr_orm"].delete(query="*:*")
         app.config["_solr_orm"].commit()

--- a/tests/controllers/test_access_request.py
+++ b/tests/controllers/test_access_request.py
@@ -98,6 +98,41 @@ class TestAccessRequest(BaseTest):
         )
         self.assertEqual(rv.status_code, 200)
 
+    @patch("flask_login.utils._get_user")
+    def test_email_valid_form_sends_the_request(self, current_user):
+        """A valid submission must bind the posted data and send the email,
+        the form used to be built without the request data."""
+        app.config["ACCESS_HANDLERS"] = {"dataset": "Email"}
+        current_user.return_value = User("test", "test@example.org", "Test User")
+        with mail.record_messages() as outbox:
+            rv = app.test_client().post(
+                url_for(
+                    "request_access", entity_name="dataset", entity_id=self.dataset_id
+                ),
+                data={"message": "I would like to study this dataset"},
+            )
+        self.assertEqual(rv.status_code, 302)
+        self.assertEqual(len(outbox), 1)
+        self.assertIn("I would like to study this dataset", outbox[0].body)
+
+    def test_email_valid_form_sends_the_request_anonymous(self):
+        app.config["ACCESS_HANDLERS"] = {"dataset": "Email"}
+        app.config["REQUIRE_LOGIN_ACCESS_REQUEST"] = False
+        with mail.record_messages() as outbox:
+            rv = app.test_client().post(
+                url_for(
+                    "request_access", entity_name="dataset", entity_id=self.dataset_id
+                ),
+                data={
+                    "name": "Someone",
+                    "email": "someone@example.org",
+                    "message": "Please give me access",
+                },
+            )
+        self.assertEqual(rv.status_code, 302)
+        self.assertEqual(len(outbox), 1)
+        self.assertIn("someone@example.org", outbox[0].body)
+
     @unittest.skip("Not included in the test")
     def test_mail(self):
         with mail.record_messages() as outbox:


### PR DESCRIPTION
Adds a `REQUIRE_LOGIN_ACCESS_REQUEST` setting, defaulting to `True`, checked in the `request_access` view. Anonymous users are redirected to login for every dataset, whatever the configured access handler — previously only the REMS e2e flow and the redcap handler required it, while the email handler (and REMS without `e2e`/`form_id`) accepted anonymous submissions.

Set it to `False` to restore the old per-handler behaviour.

Since every request now comes from an identified user, the captcha is also dropped from the email form for logged in users — it only ever guarded against anonymous bot submissions, and the REMS e2e form never had one. Deleting a wtforms field sets it to `None` rather than removing the attribute, so the recaptcha error check switched from `hasattr` to `getattr`; without that an invalid submission from a logged in user would raise on `None.errors`.

Also fixes a pre-existing bug found while tracing the captcha: the email form was never bound to the submitted data, so no email access request could ever validate. `9daf47e0` changed the view to pass `formdata=None` so FlaskForm would handle `request.files` for the REMS attachments, but passing `None` explicitly is precisely what disables that pickup. The REMS handler was adapted at the time, the email handler was not. It now builds the form with no arguments in that case, like the REMS handler does. The existing test did not catch it because it only asserted a 200, which is what the invalid-form re-render returns.

Note: requiring login is a behaviour change for instances using the email handler. It fails closed — if no authentication backend is configured, access requests are no longer possible.